### PR TITLE
add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # textlint-rule-ja-yahoo-kousei
-textlint rule that using Yahoo Proofreading API.
+[textlint](https://github.com/textlint/textlint) rule that using [Yahoo Proofreading API](http://developer.yahoo.co.jp/webapi/jlp/kousei/v1/kousei.html).
 
 ## Installation
 
@@ -8,6 +8,7 @@ npm install textlint-rule-ja-yahoo-kousei
 ```
 
 ## Usage
+Should get Yahoo Application ID [here](https://e.developer.yahoo.co.jp/dashboard/).
 
 ```
 npm install -g textlint textlint-rule-ja-yahoo-kousei

--- a/src/ja-yahoo-kousei.js
+++ b/src/ja-yahoo-kousei.js
@@ -28,6 +28,10 @@ function fetchProofreading(text) {
 }
 
 export default function(context, options = {}) {
+  if (!process.env.YAHOO_APP_ID) {
+    throw new Error(`YAHOO_APP_ID is not set.`);
+  }
+
   options = assign({}, defaultOptions, options);
   let {Syntax, getSource, report, RuleError} = context;
 
@@ -37,6 +41,9 @@ export default function(context, options = {}) {
         const paragraph = getSource(node);
 
         fetchProofreading(paragraph).then(json => {
+          if (json.Error) {
+            return reject(new Error(json.Error.Message[0]));
+          }
 
           if (json && json.ResultSet.Result) {
             json.ResultSet.Result.forEach(result => {


### PR DESCRIPTION
Add Error Handling.
- throw Error when environment variable YAHOO_APP_ID is not set.
- throw Error when Yahooo API response has Error.
