### PR TITLE
「無視するワード一覧」にワイルドカードを使用

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,28 @@ $ textlint --rule textlint-rule-ja-yahoo-kousei README.md
 
 ## Config
 
+You can set words that ignore.
+
 ```
 {
   "rules": {
     "textlint-rule-ja-yahoo-kousei": {
       'ignores': {
         '用字':['彼方']
+      }
+    }
+  }
+}
+```
+
+or use wildcard;
+
+```
+{
+  "rules": {
+    "textlint-rule-ja-yahoo-kousei": {
+      'ignores': {
+        '用字': '*'
       }
     }
   }

--- a/src/ja-yahoo-kousei.js
+++ b/src/ja-yahoo-kousei.js
@@ -42,6 +42,22 @@ function getReportMessage(record, lang = 'en') {
   }
 }
 
+function containedIgnoreList(word, info, ignores) {
+  const target = ignores[info];
+  
+  if (!target) {
+    return false;
+  }
+  else if (target === '*') {
+    return true;
+  }
+  else if (Array.isArray(target)) {
+    return !!find(target, w => w === word);
+  }
+  
+  return false;
+}
+
 export default function(context, options = {}) {
   const appID = options.appID || process.env.YAHOO_APP_ID;
 
@@ -64,11 +80,8 @@ export default function(context, options = {}) {
 
           if (json && json.ResultSet.Result) {
             json.ResultSet.Result.forEach(result => {
-              const info = result.ShitekiInfo[0];
-              const ignore = options.ignores[info]
-                  && find(options.ignores[info], w => w === result.Surface[0]);
-
-              if (ignore) return;
+              
+              if (containedIgnoreList(result.Surface[0], result.ShitekiInfo[0], options.ignores)) return;
 
               report(node, new RuleError(getReportMessage(result, options.lang)));
             });

--- a/test/yahoo-kousei-test.js
+++ b/test/yahoo-kousei-test.js
@@ -23,19 +23,41 @@ describe('yahoo-kousei', function() {
   });
 
   context('when use filter config', () => {
-    const textlint = new TextLintCore();
-
-    textlint.setupRules({
-      'ja-yahoo-kousei': rule
-    }, {
-      'ja-yahoo-kousei': {
-        'ignores': {
-          '用字':['彼方']
-        }
-      }
-    });
 
     it('should report filtered error', (done) => {
+
+      const textlint = new TextLintCore();
+
+      textlint.setupRules({
+        'ja-yahoo-kousei': rule
+      }, {
+        'ja-yahoo-kousei': {
+          'ignores': {
+            '用字':['彼方']
+          }
+        }
+      });
+
+      // sample text from
+      // http://developer.yahoo.co.jp/webapi/jlp/kousei/v1/kousei.html
+      textlint.lintMarkdown('遙か彼方に小形飛行機が見える。').then(result => {
+        assert(result.messages.length === 2);
+      }).then(done, done);
+    });
+    
+    it('should report filtered error(use wildcard)', (done) => {
+
+      const textlint = new TextLintCore();
+
+      textlint.setupRules({
+        'ja-yahoo-kousei': rule
+      }, {
+        'ja-yahoo-kousei': {
+          'ignores': {
+            '用字': '*'
+          }
+        }
+      });
 
       // sample text from
       // http://developer.yahoo.co.jp/webapi/jlp/kousei/v1/kousei.html


### PR DESCRIPTION
下記の形式でワイルドカードをサポート。

```
{
  "rules": {
    "textlint-rule-ja-yahoo-kousei": {
      'ignores': {
        '用字': '*'
      }
    }
  }
}
```
